### PR TITLE
add ability to configure SRTO_LOSSMAXTTL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type AppConfig struct {
 	Latency     uint
 	Buffersize  uint
 	SyncClients bool
+	LossMaxTTL  uint
 }
 
 type AuthConfig struct {
@@ -55,6 +56,7 @@ func Parse(paths []string) (*Config, error) {
 		App: AppConfig{
 			Address:     "127.0.0.1:1337",
 			Latency:     200,
+			LossMaxTTL:  0,
 			Buffersize:  384000,
 			SyncClients: false,
 		},

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 		Server: srt.ServerConfig{
 			Address:     conf.App.Address,
 			Latency:     conf.App.Latency,
+			LossMaxTTL:  conf.App.LossMaxTTL,
 			SyncClients: conf.App.SyncClients,
 			Auth:        auth,
 		},

--- a/srt/server.go
+++ b/srt/server.go
@@ -33,6 +33,7 @@ type ServerConfig struct {
 	Address     string
 	Port        uint16
 	Latency     uint
+	LossMaxTTL  uint
 	Auth        auth.Authenticator
 	SyncClients bool
 }
@@ -103,6 +104,7 @@ func (s *ServerImpl) listenAt(ctx context.Context, host string, port uint16) err
 	options["latency"] = strconv.Itoa(int(s.config.Latency))
 
 	sck := srtgo.NewSrtSocket(host, port, options)
+	sck.SetSockOptInt(C.SRTO_LOSSMAXTTL, int(s.config.LossMaxTTL))
 	err := sck.Listen(1)
 	if err != nil {
 		return fmt.Errorf("Listen failed: %v", err)

--- a/srt/server.go
+++ b/srt/server.go
@@ -104,7 +104,7 @@ func (s *ServerImpl) listenAt(ctx context.Context, host string, port uint16) err
 	options["latency"] = strconv.Itoa(int(s.config.Latency))
 
 	sck := srtgo.NewSrtSocket(host, port, options)
-	sck.SetSockOptInt(C.SRTO_LOSSMAXTTL, int(s.config.LossMaxTTL))
+	sck.SetSockOptInt(srtgo.SRTO_LOSSMAXTTL, int(s.config.LossMaxTTL))
 	err := sck.Listen(1)
 	if err != nil {
 		return fmt.Errorf("Listen failed: %v", err)


### PR DESCRIPTION
This feature is a bit selfish because I only need to be able to configure lossmaxttl, but happy to adjust the API to accommodate other socket options if you have any suggestions.