### PR TITLE
readme: fix file extensions in docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ffplay -fflags nobuffer srt://localhost:1337?streamid=play/test
 Start docker with custom config. See [config.toml.example](config.toml.example)
 ```bash
 # provide your own config from the local directory
-docker run -v $(pwd)/config.yml:/home/srtrelay/config.yml ghcr.io/voc/srtrelay/srtrelay:latest
+docker run -v $(pwd)/config.toml:/home/srtrelay/config.toml ghcr.io/voc/srtrelay/srtrelay:latest
 ```
 
 ## Build with docker


### PR DESCRIPTION
README still mentions YAML files, but the code only supports TOML as far as I can see.