### PR TITLE
Add `listen_timeout` to config

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -23,6 +23,15 @@ addresses = ["localhost:1337"]
 # Clients which are more than buffersize behind the live edge are disconnected.
 #buffersize = 384000
 
+# SRT protocol `lossmaxttl` value. Default 0 disables the mechanism. This is an advanced configuration, see
+# http://underpop.online.fr/f/ffmpeg/help/haivision-secure-reliable-transport-protocol.htm.gz
+# for more info
+#lossMaxTTL = 0
+
+# SRT protocol `listen_timeout`, value set in milliseconds. Sets the socket listen timeout, or the
+# maximum time to wait for a response from the client before dropping the connection
+#listen_timeout = 3000
+
 # Experimental: synchronize MPEG-TS clients to a GOP start
 # This should not increase playback delay, just make sure the client always
 # starts with a clean packet stream.

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type AppConfig struct {
 	Addresses     []string
 	PublicAddress string
 	Latency       uint
+	ListenTimeout uint
 	Buffersize    uint
 	SyncClients   bool
 	LossMaxTTL    uint
@@ -76,6 +77,7 @@ func Parse(paths []string) (*Config, error) {
 		App: AppConfig{
 			Addresses:   []string{"localhost:1337"},
 			Latency:     200,
+			ListenTimeout: 3000,
 			LossMaxTTL:  0,
 			Buffersize:  384000,
 			SyncClients: false,

--- a/srt/server.go
+++ b/srt/server.go
@@ -33,6 +33,7 @@ type ServerConfig struct {
 	Addresses     []string
 	PublicAddress string
 	Latency       uint
+	ListenTimeout uint
 	LossMaxTTL    uint
 	Auth          auth.Authenticator
 	SyncClients   bool
@@ -130,6 +131,7 @@ func (s *ServerImpl) listenAt(ctx context.Context, host string, port uint16) err
 	options := make(map[string]string)
 	options["blocking"] = "0"
 	options["transtype"] = "live"
+	options["listen_timeout"] = strconv.Itoa(int(s.config.ListenTimeout))
 	options["latency"] = strconv.Itoa(int(s.config.Latency))
 
 	sck := srtgo.NewSrtSocket(host, port, options)


### PR DESCRIPTION
Adds an option to configure `listen_timeout` parameter to config file. Also documents that `lossmaxttl` config exists in the example.