### PR TITLE
fixed incompatibility with non amd64 platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && \
 
 COPY . /build
 WORKDIR /build
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -v -o srtrelay .
+ARG TARGETARCH
+RUN GOOS=linux GOARCH=$TARGETARCH go build -ldflags="-w -s" -v -o srtrelay .
 
 # clean start
 FROM debian:bullseye


### PR DESCRIPTION
This change allows the docker image to be build on non amd64 platforms.

It tested to build successfully on amd64 and arm64.