### PR TITLE
Add relay metrics

### DIFF
--- a/api/metrics.go
+++ b/api/metrics.go
@@ -1,32 +1,30 @@
 package api
 
 import (
+	"github.com/voc/srtrelay/config"
 	"github.com/voc/srtrelay/srt"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	namespace    = "srtrelay"
-	srtSubsystem = "srt"
-)
+const srtSubsystem = "srt"
 
 var (
 	activeSocketsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, srtSubsystem, "active_sockets"),
+		prometheus.BuildFQName(config.MetricsNamespace, srtSubsystem, "active_sockets"),
 		"The number of active SRT sockets",
 		nil, nil,
 	)
 
 	// Metrics from: https://pkg.go.dev/github.com/haivision/srtgo#SrtStats
 	pktSentTotalDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, srtSubsystem, "packets_sent_total"),
+		prometheus.BuildFQName(config.MetricsNamespace, srtSubsystem, "packets_sent_total"),
 		"total number of sent data packets, including retransmissions",
 		[]string{"address", "stream_id"}, nil,
 	)
 
 	pktRecvTotalDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, srtSubsystem, "packets_received_total"),
+		prometheus.BuildFQName(config.MetricsNamespace, srtSubsystem, "packets_received_total"),
 		"total number of received packets",
 		[]string{"address", "stream_id"}, nil,
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,8 @@ import (
 	"github.com/voc/srtrelay/auth"
 )
 
+const MetricsNamespace = "srtrelay"
+
 type Config struct {
 	App  AppConfig
 	Auth AuthConfig

--- a/relay/channel_test.go
+++ b/relay/channel_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestChannel_PubSub(t *testing.T) {
-	ch := NewChannel(uint(1316 * 50))
+	ch := NewChannel("test", uint(1316*50))
 
 	// sub
 	out, unsub := ch.Sub()
@@ -33,7 +33,7 @@ func TestChannel_PubSub(t *testing.T) {
 }
 
 func TestChannel_DropOnOverflow(t *testing.T) {
-	ch := NewChannel(uint(1316 * 50))
+	ch := NewChannel("test", uint(1316*50))
 
 	sub, _ := ch.Sub()
 	capacity := cap(sub) + 1
@@ -60,7 +60,7 @@ func TestChannel_DropOnOverflow(t *testing.T) {
 }
 
 func TestChannel_Close(t *testing.T) {
-	ch := NewChannel(0)
+	ch := NewChannel("test", 0)
 	sub1, _ := ch.Sub()
 	_, _ = ch.Sub()
 
@@ -80,7 +80,7 @@ func TestChannel_Close(t *testing.T) {
 }
 
 func TestChannel_Stats(t *testing.T) {
-	ch := NewChannel(0)
+	ch := NewChannel("test", 0)
 	if num := ch.Stats().clients; num != 0 {
 		t.Errorf("Expected 0 clients after create, got %d", num)
 	}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -54,7 +54,7 @@ func (s *RelayImpl) Publish(name string) (chan<- []byte, error) {
 		return nil, ErrStreamAlreadyExists
 	}
 
-	channel := NewChannel(s.config.BufferSize / s.config.PacketSize)
+	channel := NewChannel(name, s.config.BufferSize/s.config.PacketSize)
 	s.channels[name] = channel
 
 	ch := make(chan []byte)


### PR DESCRIPTION
Add Prometheus metrics to the relay package. The new metrics match the existing Stats struct.
* Pass the channel name to the NewChannel func so it can be used as a label.
* Refactor metrics namespace into the config package.